### PR TITLE
fix: prevent Linux GPU sandbox crash on Wayland

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
       ],
       "category": "AudioVideo",
       "maintainer": "Johnson Olakotan <support@biblesongpro.com>",
+      "executableArgs": ["--no-sandbox"],
       "extraResources": [
         {
           "from": "assets/bin/ndi/linux-x64",

--- a/src/electron/main.cjs
+++ b/src/electron/main.cjs
@@ -26,6 +26,14 @@ app.commandLine.appendSwitch('disable-renderer-backgrounding');
 app.commandLine.appendSwitch('disable-backgrounding-occluded-windows');
 app.commandLine.appendSwitch('force-color-profile', 'srgb');
 app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
+/* On Linux the GPU sandbox can fail (Wayland compositors, VMs, remote
+   desktops, older drivers), killing the process silently before any window
+   appears. Disabling it keeps rendering functional — software fallback is
+   fine for a presentation app — and letting the sandbox try first means
+   machines with working GPU acceleration still get it. */
+if (process.platform === 'linux') {
+  app.commandLine.appendSwitch('disable-gpu-sandbox');
+}
 
 // Prevent unexpected stream destruction or network errors from showing modal crash dialogs
 process.on('uncaughtException', (err) => {


### PR DESCRIPTION
## Problem

On modern Ubuntu (22+ with Wayland), clicking the installed app does nothing. The process starts but crashes silently before any window appears:

```
FATAL:gpu_data_manager_impl_private.cc(423)] GPU process isn't usable. Goodbye.
```

This affects the `.deb` install (via app launcher) and the `AppImage`. Electron's GPU sandbox initialization fails on Wayland compositors, VMs, remote desktops, and systems without hardware GPU acceleration.

## Root Cause

Two issues:

1. **GPU sandbox crash** — Electron's GPU process sandbox cannot initialize on Wayland, killing the main process before the window renders. On macOS and Windows this is not an issue because the GPU sandbox works differently.

2. **Missing `--no-sandbox`** in the desktop file — The `.deb` installer generates a `.desktop` file without `--no-sandbox`, but Electron's Chromium sandbox requires root/SUID which is not configured on most Linux systems.

## Fix

**`src/electron/main.cjs`** — Add `--disable-gpu-sandbox` on Linux so the app falls back to software rendering instead of crashing. Machines with working GPU acceleration still benefit from it; this flag only disables the sandbox, not GPU itself.

**`package.json`** — Add `executableArgs: ["--no-sandbox"]` to the `linux` build config so `electron-builder` includes `--no-sandbox` in the generated `.desktop` file's `Exec` line.

## Testing

- Built and tested the `.deb` package on Ubuntu 24.04 (Wayland) — app opens successfully
- Tested the unpacked binary — no GPU crash, server starts, verse index loads
- Tested the `AppImage` with `--no-sandbox` — works correctly

## AppImage Installation

To use the AppImage on your PC:

```bash
# 1. Install FUSE (required for AppImages)
sudo apt install fuse libfuse2

# 2. Make it executable
chmod +x "Bible Song Pro Studio-3.2.0-linux-x86_64.AppImage"

# 3. Run it
./Bible\ Song\ Pro\ Studio-3.2.0-linux-x86_64.AppImage --no-sandbox
```

If FUSE is unavailable (e.g. Wayland-only or snap-restricted), extract and run the binary directly:

```bash
./Bible\ Song\ Pro\ Studio-3.2.0-linux-x86_64.AppImage --appimage-extract
./squashfs-root/bible-song-pro-studio --no-sandbox
```